### PR TITLE
Add esm4p2 fre make example yamls

### DIFF
--- a/ESM4p2/compile.yaml
+++ b/ESM4p2/compile.yaml
@@ -1,0 +1,124 @@
+compile:
+     experiment: "esm4"
+     container_addlibs: 
+     baremetal_linkerflags:  
+     src:
+          - component: "FMS"
+            repo: "https://github.com/NOAA-GFDL/FMS.git"
+            cppdefs: "-Duse_libMPI -Duse_netCDF -DMAXFIELDMETHODS_=500"
+            branch: *FMS_GIT_TAG 
+          - component: "atmos_phys"
+            requires: ["FMS"]
+            repo: "https://gitlab.gfdl.noaa.gov/FMS/atmos_phys.git"
+            branch: *ATM_PHYS_GIT_TAG 
+            otherFlags: *FMSincludes
+          - component: "atmos_dyn"
+            requires: ["FMS", "atmos_phys"]
+            repo: "https://github.com/NOAA-GFDL/GFDL_atmos_cubed_sphere.git"
+            cppdefs: "-DSPMD -DCLIMATE_NUDGE -DINTERNAL_FILE_NML"
+            otherFlags: *FMSincludes
+            branch: *ATM_FV3_GIT_TAG 
+            paths: [ "atmos_dyn/driver/GFDL",
+                     "atmos_dyn/model",
+                     "atmos_dyn/model_nh_null",
+                     "atmos_dyn/GFDL_tools",
+                     "atmos_dyn/driver/SHiELD/cloud_diagnosis.F90",
+                     "atmos_dyn/driver/SHiELD/gfdl_cloud_microphys.F90",
+                     "atmos_dyn/tools" ]
+          - component: "atmos_drivers"
+            requires: ["FMS", "atmos_phys", "atmos_dyn"]
+            repo: "https://github.com/NOAA-GFDL/atmos_drivers.git"
+            cppdefs: "-DSPMD -DCLIMATE_NUDGE"
+            branch: *ATM_DRV_GIT_TAG 
+            otherFlags: *FMSincludes
+            paths: ["atmos_drivers/coupled"]
+          - component: "lm4p"
+            requires: ["FMS"]
+            repo: "https://gitlab.gfdl.noaa.gov/FMS/lm4p.git"
+            branch: *LAND_GIT_TAG 
+            cppdefs: "-DINTERNAL_FILE_NML"
+            otherFlags: *FMSincludes
+          - component: "mom6" 
+            requires: ["FMS"]
+            repo: ["https://github.com/NOAA-GFDL/MOM6-examples.git",
+                   "https://github.com/NOAA-GFDL/ocean_BGC.git" ]
+            branch: [ "dev/gfdl", *OCEAN_BGC_GIT_TAG ] # cant use property for mom6 since its a commit hash instead of a branch
+            otherFlags: !join [ *FMSincludes, " ", *MOMincludes ]
+            additionalInstructions: |
+              pushd mom6/MOM6-examples
+              git checkout 40e3937 # this is just the value of MOM6_GIT_TAG property, can't seem to use variable 
+              popd
+              # this step might be covered by initial checkout since the default is recursive
+              git submodule update --recursive --init mom6/MOM6-examples/src/MOM6 mom6/MOM6-examples/src/SIS2 mom6/MOM6-examples/src/icebergs
+              # checkout dev/gfdl on the icebergs submodule
+              pushd mom6/MOM6-examples/src/icebergs
+              git checkout dev/gfdl
+              popd
+              # this is different than the MOM6_GIT_TAG above since its pulling a submodule not the whole repo
+              if [[ $MOM6_GIT_FIX ]]; then
+                echo WARNING: Checking out MOM6_GIT_FIX, set to: $MOM6_GIT_FIX
+                pushd mom6/MOM6-examples/src/MOM6/
+                git checkout $MOM6_GIT_FIX
+                popd
+              fi 
+              if [[ $SIS2_GIT_FIX ]]; then
+                echo WARNING: Checking out SIS2_GIT_FIX, set to: $SIS2_GIT_FIX 
+                pushd mom6/MOM6-examples/src/SIS2/
+                git checkout $SIS2_GIT_FIX
+                popd
+              fi
+              # link in dataset
+              pushd mom6/MOM6-examples
+              # skip the check for orion
+              #set platform_domain = `perl -T -e "use Net::Domain(hostdomain) ; print hostdomain"`
+              #if ("${platform_domain}" =~ *"MsState"* ) then
+              #  ln -s /work/noaa/gfdlscr/pdata/gfdl/gfdl_O/datasets/ .datasets
+              #else
+                ln -s /gpfs/f5/gfdl_o/world-shared/datasets .datasets
+              #endif
+              popd  
+              test -e mom6/.datasets
+              if [[ $status != 0 ]]; then
+                echo ""; echo "" ; echo "   WARNING:  .datasets link in MOM6 examples directory is invalid"; echo ""; echo ""
+              fi 
+            cppdefs: "-DMAX_FIELDS_=100 -DNOT_SET_AFFINITY -D_USE_MOM6_DIAG -D_USE_GENERIC_TRACER  -DUSE_PRECISION=2"
+            paths: [ "mom6/MOM6-examples/src/MOM6/config_src/infra/FMS2",
+                     "mom6/MOM6-examples/src/MOM6/config_src/memory/dynamic_symmetric",
+                     "mom6/MOM6-examples/src/MOM6/config_src/drivers/FMS_cap",
+                     "mom6/MOM6-examples/src/MOM6/src/ALE",
+                     "mom6/MOM6-examples/src/MOM6/src/core",
+                     "mom6/MOM6-examples/src/MOM6/src/diagnostics",
+                     "mom6/MOM6-examples/src/MOM6/src/equation_of_state",
+                     "mom6/MOM6-examples/src/MOM6/src/framework",
+                     "mom6/MOM6-examples/src/MOM6/src/ice_shelf",
+                     "mom6/MOM6-examples/src/MOM6/src/initialization",
+                     "mom6/MOM6-examples/src/MOM6/src/ocean_data_assim",
+                     "mom6/MOM6-examples/src/MOM6/src/parameterizations",
+                     "mom6/MOM6-examples/src/MOM6/src/tracer",
+                     "mom6/MOM6-examples/src/MOM6/src/user",
+                     "mom6/MOM6-examples/src/MOM6/config_src/external/ODA_hooks",
+                     "mom6/MOM6-examples/src/MOM6/config_src/external/database_comms",
+                     "mom6/MOM6-examples/src/MOM6/config_src/external/drifters",
+                     "mom6/MOM6-examples/src/MOM6/config_src/external/stochastic_physics",
+                     "mom6/MOM6-examples/src/MOM6/config_src/external/stochastic_physics",
+                     "mom6/ocean_BGC/generic_tracers",
+                     "mom6/ocean_BGC/mocsy/src" ]
+          - component: "sis2" 
+            requires: ["FMS", "mom6"]
+            repo: "https://github.com/NOAA-GFDL/ice_param.git"
+            branch: "2024.01"
+            cppdefs: "-DUSE_FMS2_IO"
+            otherFlags: !join [ *FMSincludes, " ", *MOMincludes ]
+            paths: [ "mom6/MOM6-examples/src/SIS2/config_src/dynamic_symmetric", 
+                     "mom6/MOM6-examples/src/SIS2/config_src/external/Icepack_interfaces",
+                     "mom6/MOM6-examples/src/SIS2/src",
+                     "mom6/MOM6-examples/src/icebergs/src",
+                     "sis2" ]
+          - component: "coupler"
+            requires: ["FMS", "atmos_dyn", "atmos_drivers", "atmos_phys", "lm4p", "sis2", "mom6"]
+            repo: "https://github.com/NOAA-GFDL/FMScoupler"
+            branch: "2024.01"
+            otherFlags: !join [ *FMSincludes, " ", *MOMincludes ]
+            paths: [ "coupler/shared",
+                     "coupler/full" ]
+

--- a/ESM4p2/esm4.yaml
+++ b/ESM4p2/esm4.yaml
@@ -1,0 +1,86 @@
+# esm4.2, based off ESM4p2_piControl_spinup_J_rts.xml
+# this needs -npc (non-parallel checkout) flag during checkout script creation for additional checkouts to work properly
+fre_properties:
+  - &RELEASE              "2024.01"
+  - &FMS_GIT_TAG          "2024.01" 
+  - &ATM_PHYS_GIT_TAG     "2024.01-alpha6" 
+  - &ATM_FV3_GIT_TAG      "2023.03"
+  - &ATM_DRV_GIT_TAG      "2023.04"
+  - &LAND_GIT_TAG         "2024.01"
+  - &ICE_PARAM_GIT_TAG    "2023.04"
+  - &ESM4_VERSION         "2024.01"
+  - &OCEAN_BGC_GIT_TAG    "dev4.2_benthic"
+  - &MOM6_DATE            "20231130"
+  - &MOM6_GIT_TAG         "40e3937"
+  - &MOM6_GIT_FIX         ""
+  - &SIS2_GIT_FIX         ""
+  # compile
+  - &FRE_STEM             !join [fre/FMS, *RELEASE, _mom6_, *MOM6_DATE] 
+  - &INTEL                "intel-classic"
+  - &FMSincludes          "-IFMS/include"
+  - &MOMincludes          "-Imom6/MOM6-examples/src/MOM6/src/framework"
+  # post processing
+  - &OM4_ANALYSIS         "ice_ocean_SIS2/OM4_05"
+  - &PROD_SIMTIME         "5"        # simulation length in years
+  - &PP_CMIP_CHUNK_A      "5yr"      # smaller chunk length for pp/analysis
+  - &PP_CMIP_CHUNK_B      "10yr"     # bigger  chunk length for pp/analysis
+  - &PP_START_YEAR        "0001"     # starting year
+  - &PROD_RUNTIME         "16:00:00" # Maximum wall clock per simulation
+  - &PROD_SEGTIME         "03:00:00" # Wall clock per segment (usually 1 year)
+  # MDBI settings
+  - &EXP_CPLD_START       "0001"     # simulation start year
+  - &EXP_CPLD_END         "1000"     # simulation end   year
+  # this property wasn't actually used in the xml, but seems to be intended for specifying reference files to verify regression tests
+  - &reference_tag        "FMS2022.03_mom6_20220703"
+  # these properties modify the build
+  - &BUILD_DATE            "" # included as part of the src directory path
+  - &MODIFIER              "" # appended to compile experiment name, can likely remove since compile experiments are no longer a thing
+  - &PLATINFO              "" # used for awg_input 
+  - &LIBS_ROOT             "esm4.2_compile$(MODIFIER)" # used below
+  - &SRC_DIR               !join [ $root/, *BUILD_DATE, /, *LIBS_ROOT, /src] # this ends up being used for input paths
+  - &MOM6_EXAMPLES         !join [ $root/, *BUILD_DATE, /, *LIBS_ROOT, /src/mom6] # also for input paths
+  # input paths
+  - &AWG_INPUT_HOME_GAEA   "awg_include"
+  - &AWG_INPUT_HOME_NESCC  "awg_include"
+  - &AWG_INPUT_HOME_GFDL   !join [ /nbhome/$USER/, *FRE_STEM, *PLATINFO, /$(name)/mdt_xml/awg_include]
+  - &USER_FILES_F2toF5     "/gpfs/f5/gfdl_f/world-shared/Niki.Zadeh/archive/input/f2_user_files_in_xmls"
+  - &append_to_setup_csh    "" # The start year of forcing dataset. FRE hack to set fyear
+
+build:
+  compileYaml: "compile.yaml"
+  platformYaml: "platforms.yaml"
+
+shared:
+  # directories shared across tools
+  # shamelessly stolen from am5 example
+  directories: &shared_directories
+    history_dir:  !join [/archive/$USER/, *FRE_STEM, /, *name, /, *platform, -, *target, /, history]
+    pp_dir:       !join [/archive/$USER/, *FRE_STEM, /, *name, /, *platform, -, *target, /, pp]
+    analysis_dir: !join [/nbhome/$USER/, *FRE_STEM, /, *name]
+    ptmp_dir:     "/xtmp/$USER/ptmp"
+    fre_analysis_home: "/home/fms/local/opt/fre-analysis/test"
+
+  # shared pp settings
+  # also shamelessly stolen from am5 example
+  postprocess: 
+    settings: &shared_settings
+      history_segment:    "P1Y"
+      site:               "ppan"
+    switches: &shared_switches
+      do_statics:         True
+      do_timeavgs:        True
+      clean_work:         True
+      do_refinediag:      False
+      do_atmos_plevel_masking: True
+      do_preanalysis:     False
+      do_analysis:        True
+
+experiments:
+  - name: "ESM4p2_piControl_spinup_J"
+    pp:
+  - name: "ESM4p2_piControl_spinup_Jb"
+    pp:
+  - name: "ESM4p2_piControl_spinup_J_redoyr450_btmdiags"
+    pp:
+  - name: "ESM4p2_piControl_spinup_J_redoyr450"
+    pp:

--- a/ESM4p2/platforms.yaml
+++ b/ESM4p2/platforms.yaml
@@ -1,0 +1,18 @@
+platforms:
+   - name: ncrc5.intel23
+     compiler: intel
+     modulesInit: [" module use -a /ncrc/home2/fms/local/modulefiles \n","source $MODULESHOME/init/sh \n"]
+     modules: [ !join [*INTEL, "/2023.2.0"],"fre/bronx-21",cray-hdf5/1.12.2.11, cray-netcdf/4.9.0.11]
+     fc: ftn
+     cc: cc
+     mkTemplate: !join ["/ncrc/home2/fms/local/opt/fre-commands/bronx-20/site/ncrc5/", *INTEL, ".mk"]
+     modelRoot: ${HOME}/fremake_canopy/test
+   - name: hpcme.2023
+     compiler: intel
+     RUNenv: [". /spack/share/spack/setup-env.sh", "spack load libyaml", "spack load netcdf-fortran@4.5.4", "spack load hdf5@1.14.0"]
+     modelRoot: /apps
+     fc: mpiifort
+     cc: mpiicc
+     container: True
+     containerBuild: "podman"
+     containerRun: "apptainer" 


### PR DESCRIPTION
adds the esm4p2 yamls from the fre-cli repo.

I think everything from fre/make/tests is here already besides this one, but let me know if I should copy anything else over.